### PR TITLE
Make GitHub detect *.eForth as Forth.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.eForth linguist-language=Forth


### PR DESCRIPTION
Hello,

Please merge this, if you like GitHub to detect your `.eForth` files as Forth.  It will also make your repository be identified as Forth.

Thanks!
